### PR TITLE
fix: bump python version to 3.14

### DIFF
--- a/.github/workflows/lint_format_checker.yaml
+++ b/.github/workflows/lint_format_checker.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.11" ]
+        python-version: [ "3.14" ]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,6 +1,6 @@
 # This workflow use pytest:
 #  - Install Python dependencies.
-#  - Run pytest for each of the supported Python versions ["3.8", "3.9", "3.10"]. 
+#  - Run pytest for each of the supported Python versions ["3.14"]. 
 # Running pytest with -m "no docker" to disable test that require a docker installation.
 
 name: Pytest.
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11"]
+        python-version: ["3.14"]
 
     steps:
     - uses: actions/checkout@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.19-alpine as amass_build
+FROM golang:1.26-alpine as amass_build
 RUN apk --no-cache add git
 RUN git clone --depth 1 https://github.com/OWASP/Amass.git /opt/amass \
     && cd /opt/amass \
     && go get ./... &&  \
     go install ./...
 
-FROM python:3.11-slim as base
+FROM python:3.14-slim as base
 FROM base as builder
 RUN mkdir /install
 WORKDIR /install
@@ -22,4 +22,4 @@ ENV PYTHONPATH=/app
 COPY agent /app/agent
 COPY ostorlab.yaml /app/agent/ostorlab.yaml
 WORKDIR /app
-CMD ["python3.11", "/app/agent/amass_agent.py"]
+CMD ["python", "/app/agent/amass_agent.py"]


### PR DESCRIPTION
## Changes

- bump python version to 3.14
- upgrade go base image version 

## Successful build

<img width="770" height="58" alt="image" src="https://github.com/user-attachments/assets/28b42bbf-c3fb-4c6b-8208-67015e894289" />

## Successful test

<img width="1110" height="254" alt="image" src="https://github.com/user-attachments/assets/7fb8fda9-5b70-42e2-ad54-fcb631e11682" />
